### PR TITLE
[REFAC] Use flutter Material Color code

### DIFF
--- a/lib/ui/colors.dart
+++ b/lib/ui/colors.dart
@@ -8,21 +8,7 @@ const colorSocialGoogle = Color(0xFFB71C1C);
 const colorSocialFacebook = Color(0xFF0D47A1);
 const colorSocialApple = Color(0xFF424242);
 
-const colorGray = {
-  600: Color(0xFF757575),
-  800: Color(0xFF424242),
-  900: Color(0xFF212121),
-};
-
 const colorWhiteTransparency = {
   70: Color(0xB3FFFFFF),
   80: Color(0xCCFFFFFF),
-};
-
-const colorLightBlue = {
-  300: Color(0xFF4FC3F7),
-};
-
-const colorRed = {
-  400: Color(0xFFEF5350),
 };

--- a/lib/ui/common/common_text_field.dart
+++ b/lib/ui/common/common_text_field.dart
@@ -9,13 +9,13 @@ class CommonTextField extends TextField {
   @override
   InputDecoration get decoration => InputDecoration(
         enabledBorder: UnderlineInputBorder(
-          borderSide: BorderSide(color: colorGray[600]),
+          borderSide: BorderSide(color: Colors.grey[600]),
         ),
         focusedBorder: UnderlineInputBorder(
           borderSide: BorderSide(color: colorLol),
         ),
         hintText: hint,
-        hintStyle: TextStyle(color: colorGray[600]),
+        hintStyle: TextStyle(color: Colors.grey[600]),
         contentPadding: EdgeInsets.only(left: 12),
       );
 

--- a/lib/ui/page/find_password_page.dart
+++ b/lib/ui/page/find_password_page.dart
@@ -36,7 +36,7 @@ class FindPasswordPage extends StatelessWidget {
           padding: EdgeInsets.all(24),
           decoration: BoxDecoration(
             borderRadius: BorderRadius.circular(12),
-            color: colorGray[900],
+            color: Colors.grey[900],
           ),
           child: Wrap(children: <Widget>[
             Column(

--- a/lib/ui/page/input_information2_page.dart
+++ b/lib/ui/page/input_information2_page.dart
@@ -58,13 +58,13 @@ class _InputInformation2PageState extends State<InputInformation2Page> {
         key: key,
         decoration: InputDecoration(
           enabledBorder: UnderlineInputBorder(
-            borderSide: BorderSide(color: colorGray[600]),
+            borderSide: BorderSide(color: Colors.grey[600]),
           ),
           focusedBorder: UnderlineInputBorder(
             borderSide: BorderSide(color: colorLol),
           ),
           hintText: '소환사 이름',
-          hintStyle: TextStyle(color: colorGray[600]),
+          hintStyle: TextStyle(color: Colors.grey[600]),
           contentPadding: EdgeInsets.only(left: 12),
         ),
         style: TextStyle(
@@ -82,7 +82,7 @@ class _InputInformation2PageState extends State<InputInformation2Page> {
         itemSubmitted: (item) {},
         itemBuilder: (context, item) => Container(
           padding: EdgeInsets.all(12),
-          color: colorGray[900],
+          color: Colors.grey[900],
           child: Row(
             children: <Widget>[
               CircleAvatar(
@@ -218,7 +218,7 @@ class RankInfoWidget extends StatelessWidget {
         padding: EdgeInsets.only(top: 12, left: 32, right: 32, bottom: 8),
         decoration: BoxDecoration(
           borderRadius: BorderRadius.circular(20),
-          color: colorGray[900],
+          color: Colors.grey[900],
         ),
         child: Column(
           children: <Widget>[
@@ -290,7 +290,7 @@ class MostInfoWidget extends StatelessWidget {
                               '4.00:1',
                               style: TextStyle(
                                 fontSize: 18,
-                                color: colorLightBlue[300],
+                                color: Colors.lightBlue[300],
                               ),
                             )
                           ],
@@ -312,7 +312,7 @@ class MostInfoWidget extends StatelessWidget {
                                   '100%',
                                   style: TextStyle(
                                     fontSize: 18,
-                                    color: colorRed[400],
+                                    color: Colors.red[400],
                                   ),
                                 ),
                               ],

--- a/lib/ui/page/input_information3_page.dart
+++ b/lib/ui/page/input_information3_page.dart
@@ -62,9 +62,9 @@ class InputInformation3Page extends StatelessWidget {
             ),
           ),
           selected: false,
-          selectedColor: colorGray[900],
+          selectedColor: Colors.grey[900],
           onSelected: (selected) {},
-          backgroundColor: colorGray[800],
+          backgroundColor: Colors.grey[800],
         ),
       );
 }

--- a/lib/ui/page/login_method_page.dart
+++ b/lib/ui/page/login_method_page.dart
@@ -50,7 +50,7 @@ class LoginMethodPage extends StatelessWidget {
               padding:
                   EdgeInsets.only(left: 48, right: 48, bottom: 24, top: 14),
               decoration: BoxDecoration(
-                color: colorGray[900],
+                color: Colors.grey[900],
                 borderRadius: BorderRadius.only(
                   topLeft: Radius.circular(20),
                   topRight: Radius.circular(20),


### PR DESCRIPTION
기존엔 Color map을 직접 구현해서 코드를 관리했었습니다.
디자인에서 사용된 색상은 대부분 [The Color System](https://material.io/design/color/the-color-system.html) 에서 참조했는데,
플러터에서는 여기 명시된 색상을 모두 기본으로 제공하더군요....
